### PR TITLE
Phase 8: PDM + Semantic Release Automation

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,67 +25,82 @@ Semantic Versioning: `MAJOR.MINOR.PATCH`
 
 ---
 
-## Release Process (Automated with semantic-release)
+## Release Process (Fully Automated)
 
-### 1. Calculate Next Version
+### Single Command Release
 
 ```bash
-# Preview version bump based on commit messages
-semantic-release version --print
+# Run release - everything is automated
+pdm run semantic-release version
 ```
 
-This analyzes commits since last tag and suggests:
-- `patch` for `fix:` commits
-- `minor` for `feat:` commits
-- `major` for `feat!:` or `BREAKING CHANGE`
+This automatically:
+1. **Validates** - Runs tests, lint, format checks (via `build_command`)
+2. **Calculates** - Determines version bump from commit messages
+3. **Updates** - Bumps version in `pyproject.toml`
+4. **Generates** - Creates changelog entries
+5. **Commits** - Creates release commit
+6. **Tags** - Creates git tag
 
-### 2. Generate Changelog (Preview)
-
-```bash
-# Preview changelog
-semantic-release changelog --print
-```
-
-### 3. Create Release (Manual Confirmation)
+### 2. Push to Publish
 
 ```bash
-# Run release (updates version, creates tag, generates changelog)
-semantic-release version
-
-# Review changes
-git show
-
-# Push to trigger GitHub Release
+# Push triggers GitHub Release creation
 git push origin main --tags
 ```
 
-### 4. Publish to GitHub Release
-
-```bash
-# After push, create GitHub Release with notes
-semantic-release publish
-```
-
-**NOTE**: Current config has `upload_to_release = false` for manual control.
+CI/CD will automatically create GitHub Release with changelog.
 
 ---
 
-## Manual Release (Fallback)
+## Manual Override (If Needed)
 
-If semantic-release is unavailable:
+### Preview Version Bump
 
 ```bash
-# 1. Update pyproject.toml
-sed -i 's/^version = ".*"/version = "1.0.1"/' pyproject.toml
-
-# 2. Commit and tag
-git add pyproject.toml
-git commit -m "Release v1.0.1"
-git tag -a "v1.0.1" -m "Release v1.0.1"
-
-# 3. Push
-git push origin main --tags
+# See what version would be released
+pdm run semantic-release version --print
 ```
+
+### Preview Changelog
+
+```bash
+# See changelog entries
+pdm run semantic-release changelog --print
+```
+
+### Dry Run
+
+```bash
+# Test release without modifications
+pdm run semantic-release version --dry-run
+```
+
+---
+
+## Project Management with PDM
+
+All project commands use `pdm run`:
+
+```bash
+# Install dependencies
+pdm install
+
+# Run tests
+pdm run pytest -v
+
+# Format code
+pdm run black src/ tests/
+pdm run isort src/ tests/
+
+# Lint
+pdm run flake8 src/ tests/
+
+# Run application
+pdm run traceflux search "pattern" .
+```
+
+**Why PDM**: Manages virtual environment, dependencies, and command execution in one tool.
 
 ---
 
@@ -118,23 +133,28 @@ Releases are driven by Conventional Commits:
 
 ## Troubleshooting
 
-### Tests Fail
+### Build Command Fails (Tests/Lint)
 
-Fix the issue, re-run `semantic-release version`.
+Fix the reported issues, then re-run:
+```bash
+pdm run semantic-release version
+```
 
-### Tag Exists
+### Tag Already Exists
 
 ```bash
 git tag -d v1.0.1
 git push origin :refs/tags/v1.0.1
-semantic-release version
+pdm run semantic-release version
 ```
 
-### Preview Without Changes
+### Force Specific Version Bump
 
 ```bash
-# Dry-run mode (no file modifications)
-semantic-release version --dry-run
+# Force major/minor/patch bump
+pdm run semantic-release version --bump major
+pdm run semantic-release version --bump minor
+pdm run semantic-release version --bump patch
 ```
 
 ---

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,41 +25,54 @@ Semantic Versioning: `MAJOR.MINOR.PATCH`
 
 ---
 
-## Release Process
+## Release Process (Automated with semantic-release)
 
-### 1. Run Release Script
+### 1. Calculate Next Version
 
 ```bash
-./scripts/release.sh 1.0.1
+# Preview version bump based on commit messages
+semantic-release version --print
 ```
 
-This will:
-1. Update `pyproject.toml`
-2. Run tests (must pass)
-3. Create commit and tag
+This analyzes commits since last tag and suggests:
+- `patch` for `fix:` commits
+- `minor` for `feat:` commits
+- `major` for `feat!:` or `BREAKING CHANGE`
 
-### 2. Review
+### 2. Generate Changelog (Preview)
 
 ```bash
+# Preview changelog
+semantic-release changelog --print
+```
+
+### 3. Create Release (Manual Confirmation)
+
+```bash
+# Run release (updates version, creates tag, generates changelog)
+semantic-release version
+
+# Review changes
 git show
-```
 
-### 3. Push
-
-```bash
+# Push to trigger GitHub Release
 git push origin main --tags
 ```
 
-### 4. CI/CD Creates Release
+### 4. Publish to GitHub Release
 
-GitHub Actions will:
-1. Run tests
-2. Run linting
-3. Create GitHub Release with auto-generated notes
+```bash
+# After push, create GitHub Release with notes
+semantic-release publish
+```
+
+**NOTE**: Current config has `upload_to_release = false` for manual control.
 
 ---
 
 ## Manual Release (Fallback)
+
+If semantic-release is unavailable:
 
 ```bash
 # 1. Update pyproject.toml
@@ -73,6 +86,21 @@ git tag -a "v1.0.1" -m "Release v1.0.1"
 # 3. Push
 git push origin main --tags
 ```
+
+---
+
+## Commit Message Convention
+
+Releases are driven by Conventional Commits:
+
+| Type | Example | SemVer Impact |
+|------|---------|---------------|
+| `feat` | `feat(cli): add search command` | MINOR |
+| `fix` | `fix(scanner): handle empty input` | PATCH |
+| `feat!` | `feat(api)!: change output format` | MAJOR |
+| Others | `chore`, `docs`, `style`, `test` | None |
+
+**Full guide**: See `.github/COMMIT_CONVENTION.md`
 
 ---
 
@@ -92,17 +120,36 @@ git push origin main --tags
 
 ### Tests Fail
 
-Fix the issue, re-run script.
+Fix the issue, re-run `semantic-release version`.
 
 ### Tag Exists
 
 ```bash
 git tag -d v1.0.1
 git push origin :refs/tags/v1.0.1
-./scripts/release.sh 1.0.1
+semantic-release version
+```
+
+### Preview Without Changes
+
+```bash
+# Dry-run mode (no file modifications)
+semantic-release version --dry-run
 ```
 
 ---
 
-**Last Updated**: 2026-03-07  
-**Version**: 1.0.0
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `pyproject.toml` | semantic-release config + version |
+| `.github/COMMIT_CONVENTION.md` | Commit message guide |
+| `.github/RELEASE_PROTOCOL.md` | Detailed release protocol |
+| `CHANGELOG.md` | Auto-generated changelog |
+
+---
+
+**Last Updated**: 2026-03-10  
+**Version**: 1.0.0  
+**Tool**: python-semantic-release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,15 @@ dev = [
 traceflux = "traceflux.cli:main"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
-[tool.setuptools.packages.find]
-where = ["src"]
+[tool.pdm]
+# PDM configuration
+# Virtual environment in .venv (project-local)
+venv.in_project = true
+
+# Dev dependencies handled via [project.optional-dependencies]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -102,3 +106,30 @@ tag_format = "v{version}"
 
 # Logging
 logging_use_named_masks = true
+
+# Automated hooks (run before version bump)
+# These ensure quality gates before release
+build_command = """
+    pdm install --dev && \
+    pdm run pytest -v && \
+    pdm run black --check src/ tests/ && \
+    pdm run isort --check-only src/ tests/ && \
+    pdm run flake8 src/ tests/
+"""
+
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false
+
+[tool.semantic_release.commit_author]
+env = "GIT_COMMIT_AUTHOR"
+default = "github-actions[bot] <actions@github.com>"
+
+[tool.semantic_release.commit_parser_options]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+other_allowed_tags = ["build", "chore", "ci", "docs", "style", "refactor", "test"]
+allowed_tags = ["feat", "fix", "perf", "build", "chore", "ci", "docs", "style", "refactor", "test"]
+default_bump_level = 0
+parse_squash_commits = true
+ignore_merge_commits = true


### PR DESCRIPTION
## Summary

Implements fully automated release workflow using PDM and python-semantic-release.

## Changes

### Build System
- **Switched to pdm-backend** from setuptools
- **PDM config**: venv.in_project = true (local virtual environment)

### Release Automation
- **build_command hook**: Runs quality gates before version bump
  - pdm install --dev
  - pdm run pytest -v
  - pdm run black --check
  - pdm run isort --check-only
  - pdm run flake8
- **Blocks release** if any check fails

### Simplified Workflow
```bash
# Single command - everything automated
pdm run semantic-release version

# Push to publish
git push origin main --tags
```

## Related

- Based on: Previous PR #38 (rebased on latest main)
- Part of: Phase 8 Step 2 (Documentation)
- Ready for: Phase 8 Step 3 (Testing)